### PR TITLE
Fix multiprocessing shutdown on Windows

### DIFF
--- a/import.py
+++ b/import.py
@@ -79,30 +79,22 @@ def main():
 
     ### SEARCHER PROCESS ###
     # establish communication queues
-    search_tasks = (
-        multiprocessing.JoinableQueue()
-    )  # overkill given I'm only allowing one input path - could just pass the string
+    search_tasks = multiprocessing.JoinableQueue()
     search_results = multiprocessing.JoinableQueue()
-
-    # start searchers
-    search_consumer = photoprocesses.SearchConsumer(search_tasks, search_results)
-    search_consumer.start()
-
-    # push the incoming search path into the search process
-    search_tasks.put(paths.incoming_path)
-
-    # poison pill to close search process
-    search_tasks.put(None)
-
-    ### EXIF PROCESS ###
     exif_results = multiprocessing.JoinableQueue()
 
-    # Start exif consumers
+    # determine number of exif consumers and start searcher with fanout
     if paths.debug:
         num_consumers = 1
     else:
         num_consumers = multiprocessing.cpu_count() * 2
 
+    search_consumer = photoprocesses.SearchConsumer(
+        search_tasks, search_results, num_consumers
+    )
+    search_consumer.start()
+
+    # Start exif consumers
     logging.debug(f"exif_results: Creating {num_consumers} consumers")
     exif_consumers = [
         photoprocesses.ExifConsumer(search_results, exif_results, paths.output_path)
@@ -111,6 +103,12 @@ def main():
 
     for w in exif_consumers:
         w.start()
+
+    # push the incoming search path into the search process
+    search_tasks.put(paths.incoming_path)
+
+    # poison pill to close search process
+    search_tasks.put(None)
 
     exhausted_consumers = 0
     # Start outputting results
@@ -266,8 +264,10 @@ def main():
         w.join()
         w.close()
     search_consumer.join()
+    search_consumer.close()
 
     state_machine.et.terminate()
+    state_machine.et = None
 
     # close the queues so that we can exit cleanly
     log_file.close()

--- a/import.py
+++ b/import.py
@@ -266,8 +266,12 @@ def main():
     search_consumer.join()
     search_consumer.close()
 
-    state_machine.et.terminate()
-    state_machine.et = None
+    # Ensure the ExifTool process used by the state machine is cleaned
+    # up before the interpreter shuts down. It may already have been
+    # cleared if an earlier error occurred, so guard against None.
+    if state_machine.et:
+        state_machine.et.terminate()
+        state_machine.et = None
 
     # close the queues so that we can exit cleanly
     log_file.close()

--- a/import.py
+++ b/import.py
@@ -261,40 +261,21 @@ def main():
 
     logger.debug("\nFinished executing state machine actions, cleaning up")
 
+    # ensure worker processes have finished
     for w in exif_consumers:
-        while not w.input_queue.empty():
-            w.input_queue.get()
-            w.input_queue.task_done()
-        w.input_queue.join()
-        w.input_queue.close()
-
-        while not w.output_queue.empty():
-            w.output_queue.get()
-            w.output_queue.task_done()
-        w.output_queue.join()
-        w.output_queue.close()
-
-        w.et.terminate()
-
-        w.terminate()
         w.join()
         w.close()
+    search_consumer.join()
 
-    search_consumer.terminate()
     state_machine.et.terminate()
 
     # close the queues so that we can exit cleanly
     log_file.close()
-    search_tasks.close()
-    search_results.close()
-    exif_results.close()
 
-    # for w in exif_consumers:
-    #    print(w.input_queue.empty())
-    #    print(w.output_queue.empty())
-
-    for child in multiprocessing.active_children():
-        print(f"Active child: {child}")
+    for q in (search_tasks, search_results, exif_results):
+        q.join()
+        q.close()
+        q.join_thread()
 
     logger.debug("\nSuccessfully exiting!")
 

--- a/photo_organiser/photoprocesses.py
+++ b/photo_organiser/photoprocesses.py
@@ -68,13 +68,22 @@ class ExifConsumer(multiprocessing.Process):
         self.input_queue = input_queue
         self.output_queue = output_queue
         self.destination_root = destination_root
-        self.et = exiftool.ExifToolHelper()
+        # ExifToolHelper will be created in run() to avoid spawning
+        # helper instances in the parent process on platforms such as
+        # Windows where multiprocessing uses the "spawn" start method.
+        # Initialising the helper here would create an ExifTool process
+        # in the parent which then attempts to clean up at interpreter
+        # shutdown, resulting in noisy "can't create new thread" errors.
+        self.et = None
 
     def run(self) -> None:
         proc_name = self.name
         files_media = 0
         files_skipped = 0
         files_total = 0
+
+        # Create the helper inside the child process
+        self.et = exiftool.ExifToolHelper()
 
         try:
             while True:

--- a/photo_organiser/photoprocesses.py
+++ b/photo_organiser/photoprocesses.py
@@ -76,90 +76,97 @@ class ExifConsumer(multiprocessing.Process):
         files_skipped = 0
         files_total = 0
 
-        while True:
-            next_task = self.input_queue.get()
+        try:
+            while True:
+                next_task = self.input_queue.get()
 
-            if next_task is None:
-                # Poison pill means shutdown
-                logger.debug(
-                    f"{proc_name}: Finished exif analysis. Found {files_total} in total ({files_media} valid, {files_skipped} ignored). Process exiting successfully."
-                )
-                self.input_queue.task_done()
-                self.et.terminate()
-                self.output_queue.put(None)
-                self.input_queue.put(None)
-                break
+                if next_task is None:
+                    # Poison pill means shutdown
+                    logger.debug(
+                        f"{proc_name}: Finished exif analysis. Found {files_total} in total ({files_media} valid, {files_skipped} ignored). Process exiting successfully."
+                    )
+                    self.input_queue.task_done()
+                    self.output_queue.put(None)
+                    break
 
-            error_encountered = False
-            try:
-                metadata = self.et.get_metadata(next_task)
-            except Exception as e:
-                error_encountered = True
-
-            # find out which file in the batch caused the error - need to run get_metadata file by file to do it
-            if error_encountered:
-                metadata = []
-                for task in next_task:
-                    try:
-                        metadata.append(self.et.get_metadata(task)[0])
-                    except Exception as e:
-                        print(
-                            f"Error on {task} - usually this is caused by bad characters in the filesystem path"
-                        )
-
-            for d in metadata:
-                # now fan out - create images out of each directory search batch
-                files_total += 1
+                error_encountered = False
                 try:
-                    self.output_queue.put(
-                        imagefile.ImageFile(
-                            source_fullpath=d["SourceFile"],
-                            destination_root=self.destination_root,
-                            metadata=d,
+                    metadata = self.et.get_metadata(next_task)
+                except Exception as e:
+                    error_encountered = True
+
+                # find out which file in the batch caused the error - need to run get_metadata file by file to do it
+                if error_encountered:
+                    metadata = []
+                    for task in next_task:
+                        try:
+                            metadata.append(self.et.get_metadata(task)[0])
+                        except Exception as e:
+                            print(
+                                f"Error on {task} - usually this is caused by bad characters in the filesystem path"
+                            )
+
+                for d in metadata:
+                    # now fan out - create images out of each directory search batch
+                    files_total += 1
+                    try:
+                        self.output_queue.put(
+                            imagefile.ImageFile(
+                                source_fullpath=d["SourceFile"],
+                                destination_root=self.destination_root,
+                                metadata=d,
+                            )
                         )
-                    )
-                    logging.debug(
-                        f"{d['SourceFile']}: Pushed new media object to queue"
-                    )
-                    files_media += 1
-                    if files_total % 100 == 0:
                         logging.debug(
-                            f"{proc_name}: Found {files_total} so far. {files_media} are valid media, {files_skipped} were ignored."
+                            f"{d['SourceFile']}: Pushed new media object to queue"
                         )
+                        files_media += 1
+                        if files_total % 100 == 0:
+                            logging.debug(
+                                f"{proc_name}: Found {files_total} so far. {files_media} are valid media, {files_skipped} were ignored."
+                            )
 
-                except imagefile.ImageNotValidError as e:
-                    logging.debug(
-                        f"{proc_name}: {d['SourceFile']}: Invalid media object.  Skipped"
-                    )
-                    files_skipped += 1
+                    except imagefile.ImageNotValidError as e:
+                        logging.debug(
+                            f"{proc_name}: {d['SourceFile']}: Invalid media object.  Skipped"
+                        )
+                        files_skipped += 1
 
-            # finished processing this batch
-            self.input_queue.task_done()
+                # finished processing this batch
+                self.input_queue.task_done()
+        finally:
+            try:
+                if self.et:
+                    self.et.terminate()
+            finally:
+                self.et = None
 
 
 class SearchConsumer(multiprocessing.Process):
     input_queue: JoinableQueue
     output_queue: JoinableQueue
+    fanout: int
 
-    def __init__(self, input_queue, output_queue):
+    def __init__(self, input_queue, output_queue, fanout: int):
         multiprocessing.Process.__init__(self)
         self.input_queue = input_queue
         self.output_queue = output_queue
+        self.fanout = fanout
 
     def run(self) -> None:
         ext = [".mov", ".jpg", ".heic", ".mp4", ".png", ".jpeg", ".3gp", ".avi", ".jpe"]
-        proc_name = self.name
+        ignored: list[str] = []
         while True:
             next_task = self.input_queue.get()
             if next_task is None:
                 # Poison pill means shutdown
                 self.input_queue.task_done()
-                self.output_queue.put(None)
-                # pass on the poison pill
-                self.input_queue.put(None)
+                for _ in range(self.fanout):
+                    self.output_queue.put(None)
                 break
 
-            sf, f, ignored = run_fast_scandir(next_task, ext, self.output_queue)
+            sf, f, ign = run_fast_scandir(next_task, ext, self.output_queue)
+            ignored.extend(ign)
             # finished processing this folder
             self.input_queue.task_done()
 

--- a/photo_organiser/photoprocesses.py
+++ b/photo_organiser/photoprocesses.py
@@ -78,13 +78,14 @@ class ExifConsumer(multiprocessing.Process):
 
         while True:
             next_task = self.input_queue.get()
-            self.input_queue.task_done()
 
             if next_task is None:
                 # Poison pill means shutdown
                 logger.debug(
                     f"{proc_name}: Finished exif analysis. Found {files_total} in total ({files_media} valid, {files_skipped} ignored). Process exiting successfully."
                 )
+                self.input_queue.task_done()
+                self.et.terminate()
                 self.output_queue.put(None)
                 self.input_queue.put(None)
                 break
@@ -132,6 +133,9 @@ class ExifConsumer(multiprocessing.Process):
                     )
                     files_skipped += 1
 
+            # finished processing this batch
+            self.input_queue.task_done()
+
 
 class SearchConsumer(multiprocessing.Process):
     input_queue: JoinableQueue
@@ -147,16 +151,17 @@ class SearchConsumer(multiprocessing.Process):
         proc_name = self.name
         while True:
             next_task = self.input_queue.get()
-            self.input_queue.task_done()
             if next_task is None:
                 # Poison pill means shutdown
+                self.input_queue.task_done()
                 self.output_queue.put(None)
                 # pass on the poison pill
                 self.input_queue.put(None)
-                # self.input_queue.task_done()
                 break
 
             sf, f, ignored = run_fast_scandir(next_task, ext, self.output_queue)
+            # finished processing this folder
+            self.input_queue.task_done()
 
         ignored_file = open("ignored.log", "w", newline="", encoding="utf-8")
         ignored_writer = csv.writer(ignored_file, delimiter=",", quotechar='"')
@@ -179,11 +184,10 @@ class StatusConsumer(multiprocessing.Process):
         last_state = {}
         while True:
             next_task = self.input_queue.get()
-            self.input_queue.task_done()
             if next_task is None:
                 # Poison pill means shutdown
-                self.input_queue.put(None)
                 self.input_queue.task_done()
+                self.input_queue.put(None)
                 break
 
             # assume next_task is a dict
@@ -198,6 +202,6 @@ class StatusConsumer(multiprocessing.Process):
             if a.second % 5 == 0:
                 for t in last_state:
                     print(f'{t["proc_name"]}')
-                pass
+            self.input_queue.task_done()
 
         return


### PR DESCRIPTION
## Summary
- Ensure worker consumers call `task_done` after processing and terminate their ExifTool helpers
- Join worker processes and queues instead of terminating them forcefully for clean shutdown

## Testing
- `python -m py_compile import.py photo_organiser/photoprocesses.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a02276735c8330bd85b839f4fdb6d7